### PR TITLE
Fixed spelling for 'evalulation' with 'evaluation' on line 152

### DIFF
--- a/README.source-code-description
+++ b/README.source-code-description
@@ -149,7 +149,7 @@ src/cpu/modrm.cpp           x86 mod/reg/rm effective address handling and lookup
 
 src/cpu/mmx.cpp             Minimalist MMX register handling and effective address lookup
 
-src/cpu/lazyflags.cpp       Lazy CPU flag evalulation. CPU flags are evaluated only if needed.
+src/cpu/lazyflags.cpp       Lazy CPU flag evaluation. CPU flags are evaluated only if needed.
 
 src/cpu/flags.cpp           CPU flag evaluation code.
 


### PR DESCRIPTION
Invalid spelling located and corrected on line 152. Correct word: "evaluation." Incorrect word: "evalulation." Found in README.source-code-description.